### PR TITLE
HAC-12: NavBar Get Started Button Color Update

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -57,7 +57,7 @@ export function Navbar() {
               <span className="font-bold text-brand-600 dark:text-brand-400">
                 HackStarter
               </span>
-            </Link>
+            <Button className="hidden md:inline-flex" style={{ backgroundColor: '#50C878' }}>
           </div>
           <nav className="flex items-center gap-2">
             <Button variant="ghost" className="hidden md:inline-flex">
@@ -82,7 +82,7 @@ export function Navbar() {
                   href={item.href}
                   className="flex w-full items-center rounded-md p-2 text-sm font-medium hover:underline"
                   onClick={() => setIsMenuOpen(false)}
-                >
+              <Button className="w-full" style={{ backgroundColor: '#50C878' }}>
                   {item.name}
                 </Link>
               ))}


### PR DESCRIPTION
## 🤖 OpenAI Generated Changes

**Task:** NavBar Get Started Button Color Update
**Issue:** HAC-12

### Description:
Change the color of the "Get Started" button in the navigation bar to the new color: `#50C878`.

### Files Modified:
- **src/components/navbar.tsx**

### Patch Preview:
```patch
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -57,7 +57,7 @@ export function Navbar() {
             <Button variant="ghost" className="hidden md:inline-flex">
               Sign In
             </Button>
-            <Button className="hidden md:inline-flex bg-brand-500 hover:bg-brand-600 text-white">
+            <Button className="hidden md:inline-flex" style={{ backgroundColor: '#50C878' }}>
               Get Started
             </Button>
             <ThemeToggle />
@@ -82,7 +82,7 @@ export function Navbar() {
               <Button variant="outline" className="w-full">
                 Sign In
               </Button>
-              <Button className="w-full bg-brand-500 hover:bg-brand-600 text-white">
+              <Button className="w-full" style={{ backgroundColor: '#50C878' }}>
                 Get Started
               </Button>
             </div>
```

---
⚠️ **AI-generated code** - Please review before merging!

*Generated by OpenAI GPT-4 for HAC-12*