### PR TITLE
HAC-24: NavBar Get Started Button Color Update

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -56,7 +56,7 @@ export function Navbar() {
           <nav className="flex items-center gap-2">
             <Button variant="ghost" className="hidden md:inline-flex">
               Sign In
-            </Button>
+            <ThemeToggle />
             <Button className="hidden md:inline-flex bg-brand-500 hover:bg-brand-600 text-white">
               Get Started
             </Button>
@@ -93,4 +93,4 @@ export function Navbar() {
       )}
     </header>
   )
-}
+              <Button className="w-full" style={{ backgroundColor: '#50C878' }}>


### PR DESCRIPTION
## 🤖 OpenAI Generated Changes

**Task:** NavBar Get Started Button Color Update
**Issue:** HAC-24

### Description:
Change the color of the "Get Started" button in the navigation bar to the new color: `#50C878`.

### Files Modified:
- **src/components/navbar.tsx**

### Patch Preview:
```patch
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -56,7 +56,7 @@ export function Navbar() {
             <Button className="hidden md:inline-flex bg-brand-500 hover:bg-brand-600 text-white">
               Get Started
             </Button>
-            <ThemeToggle />
+            <ThemeToggle />
           </nav>
         </div>
       </div>
@@ -92,7 +92,7 @@ export function Navbar() {
             <div className="flex flex-col gap-2">
               <Button variant="outline" className="w-full">
                 Sign In
               </Button>
-              <Button className="w-full bg-brand-500 hover:bg-brand-600 text-white">
+              <Button className="w-full" style={{ backgroundColor: '#50C878' }}>
                 Get Started
               </Button>
             </div>
```

---
⚠️ **AI-generated code** - Please review before merging!

*Generated by OpenAI GPT-4 for HAC-24*