### PR TITLE
HAC-30: NavBar Get Started Button Color Update

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -60,7 +60,7 @@ export function Navbar() {
             <Button variant="ghost" className="hidden md:inline-flex">
               Sign In
             </Button>
-            <Button className="hidden md:inline-flex bg-brand-500 hover:bg-brand-600 text-white">
+            <Button className="hidden md:inline-flex" style={{ backgroundColor: '#50C878' }}>
               Get Started
             </Button>
             <ThemeToggle />


### PR DESCRIPTION
## 🤖 OpenAI Generated Changes

**Task:** NavBar Get Started Button Color Update
**Issue:** HAC-30

### Description:
Change the color of the "Get Started" button in the navigation bar to the new color: `#50C878`.

### Files Modified:
- **src/components/navbar.tsx**

### Files Preview:
**src/components/navbar.tsx:**
```
"use client";
import Link from "next/link";
import { Button } from "@/components/ui/button";
import { ThemeToggle } from "@/components/theme-toggle";
import { Menu, X } from "lucide-react";
import { useState } from "react";
export function Navbar() {
  const [isMenuOpen, setIsMenuOpen] = useState(false);
  const navigation = [
    { name: "Home", href: "/" },
    { name: "Features", href: "#features" },
    { name: "About", href: "#about" },
    { name: "Contact", href: "#contact" },
  ];
  retu...
[Truncated - full content applied to file]
```

---
⚠️ **AI-generated code** - Please review before merging!

*Generated by OpenAI GPT-4 for HAC-30*